### PR TITLE
06/18 | 대칭키, 비대칭키 암호화

### DIFF
--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -5,9 +5,9 @@ spring:
   application:
     name: config-service
 
-#  로컬에 있는 yml 파일을 가져오기 위한 설정
-#  profiles:
-#    active: native
+  #  로컬에 있는 yml 파일을 가져오기 위한 설정
+  #  profiles:
+  #    active: native
 
   # Rabbit MQ 관련 설정
   rabbitmq:
@@ -20,8 +20,8 @@ spring:
     config:
 
       server:
-#        native:
-#          search-locations: file//${user.home}/yml 파일 위치
+        #        native:
+        #          search-locations: file//${user.home}/yml 파일 위치
         git:
           # Repository 주소
           uri: https://github.com/parkrootseok/learn-msa
@@ -35,3 +35,7 @@ management:
     web:
       exposure:
         include: refresh, health, beans, busrefresh
+
+# 암호화 관련 설정 (대칭키 방식)
+encrypt:
+  key: 017a3dbbaece78ce0ceb

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -36,10 +36,12 @@ management:
       exposure:
         include: refresh, health, beans, busrefresh
 
-# 암호화 관련 설정 (대칭키 방식)
-#encrypt:
-#  key: 017a3dbbaece78ce0ceb
+# 암호화 관련 설정
 encrypt:
+#  대칭키 방식
+#  key: 017a3dbbaece78ce0ceb
+
+#  비대칭키 방식
   key-store:
     location: file://${user.home}/Desktop/programming/key-store/apiEncryptionKey.jks
     password: test1234

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -37,5 +37,10 @@ management:
         include: refresh, health, beans, busrefresh
 
 # 암호화 관련 설정 (대칭키 방식)
+#encrypt:
+#  key: 017a3dbbaece78ce0ceb
 encrypt:
-  key: 017a3dbbaece78ce0ceb
+  key-store:
+    location: file://${user.home}/Desktop/programming/key-store/apiEncryptionKey.jks
+    password: test1234
+    alias: apiEncryptionKey

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     name: user-service
 
   profiles:
-    active: dev
+    active: default
 
   config:
     import: optional:configserver:http://localhost:8888
@@ -23,7 +23,7 @@ spring:
   # - 기본값으로 application-name과 일치하는 yml 파일 주입
   cloud:
     config:
-      name: ecommerce
+      name: user-service
 
   # H2 DATABASE 관련 설정
   h2:
@@ -32,11 +32,6 @@ spring:
       settings:
         web-allow-others: true
       path: /h2-console
-
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb
-    username: sa
 
 eureka:
 


### PR DESCRIPTION
## ✏️  What I learned today?
- 대칭키 암호화
  - yml에 다음과 같이 대칭키를 추가
    - ```
      encrypt:
      #  암호화 관련 설정 (대칭키 방식)
      #  key: 017a3dbbaece78ce0ceb
      ```
  - localhost:${port}/encrypt에 암호화 요청할 Text를 요청 후 암호화된 Text를 추출
  - '{cipher}암호화된 Text'와 같이 기존 Text를 대체
     - 반드시 암호화를 진행했음을 알리기 위해 {cipher}를 추가해야함   

- 비대칭키 암호화
  - keytool을 이용하여 비공개 키를 생성 (암호화에 사용)
    -  ```
        keytool -genkeypair -alias apiEncryptionKey -keyalg RSA -dname "CN=rootseok, OU=API Development, O=rootseok.co.kr, L=Seoul, C=KR" -keypass "test1234" -keystore apiEnc
        ryptionKey.jks -storepass "test1234"
        ```  
  - 생성한 비공개 키를 이용하여 인증서 생성
    - ```keytool -export -alias apiEncryptionKey -keystore apiEncryptionKey.jks -rfc -file trustServer.cer```
  - 인증서를 통해 공개키를 생성 (복호화에 사용)
    -  ```keytool -import -alias trustServer -file trustServer.cer -keystore publicKey.jks```
  - 생성한 비대칭키에 대한 설정 추가
    - ```
      encrypt:
        #  암호화 관련 설정 (비대칭키 방식)
        key-store:
          location: file://${user.home}/Desktop/programming/key-store/apiEncryptionKey.jks
          password: test1234
          alias: apiEncryptionKey
        ```
   - 대칭키와 같은 방식으로 암호화를 진행한 텍스트로 평문을 대체