### PR TITLE
06/24 | Kafka를 활용한 데이터 동기화

### DIFF
--- a/order-service/src/main/java/com/example/orderservice/domain/controller/OrderController.java
+++ b/order-service/src/main/java/com/example/orderservice/domain/controller/OrderController.java
@@ -6,9 +6,11 @@ import com.example.orderservice.domain.model.request.CreateOrderRequest;
 import com.example.orderservice.domain.service.OrderService;
 import com.example.orderservice.domain.model.response.CreateOrderResponse;
 import com.example.orderservice.domain.model.response.GetOrderResponse;
-import com.example.orderservice.infra.kafka.KafkaProducer;
+import com.example.orderservice.infra.kafka.producer.KafkaProducer;
+import com.example.orderservice.infra.kafka.producer.OrderProducer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
@@ -29,6 +31,7 @@ public class OrderController {
 
     private final Environment env;
     private final KafkaProducer kafkaProducer;
+    private final OrderProducer orderProducer;
     private final OrderService orderService;
 
     @GetMapping("/health-check")
@@ -50,12 +53,14 @@ public class OrderController {
 
         OrderDto orderDto = mapper.map(createOrderRequest, OrderDto.class);
         orderDto.setUserId(userId);
-        OrderDto createOrder = orderService.createOrder(orderDto);
+        orderDto.setOrderId(UUID.randomUUID().toString());
+        orderDto.setTotalPrice(orderDto.getPrice() * orderDto.getQuantity());
 
         /* send this order to kafka */
         kafkaProducer.send("catalog-topic", orderDto);
+        orderProducer.sendCreateOrderMessage("orders", orderDto);
 
-        CreateOrderResponse response = mapper.map(createOrder, CreateOrderResponse.class);
+        CreateOrderResponse response = mapper.map(orderDto, CreateOrderResponse.class);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/order-service/src/main/java/com/example/orderservice/domain/service/OrderService.java
+++ b/order-service/src/main/java/com/example/orderservice/domain/service/OrderService.java
@@ -5,7 +5,7 @@ import com.example.orderservice.domain.model.entity.OrderEntity;
 
 public interface OrderService {
 
-    OrderDto createOrder(OrderDto orderDto);
+//    OrderDto createOrder(OrderDto orderDto);
     OrderDto getOrderByOrderId(String orderId);
     Iterable<OrderEntity> getOrdersByUserId(String userId);
 

--- a/order-service/src/main/java/com/example/orderservice/domain/service/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/example/orderservice/domain/service/OrderServiceImpl.java
@@ -17,21 +17,22 @@ public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
 
-    @Override
-    public OrderDto createOrder(OrderDto orderDto) {
-
-        ModelMapper mapper = new ModelMapper();
-        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
-        orderDto.setOrderId(UUID.randomUUID().toString());
-        orderDto.setTotalPrice(orderDto.getPrice() * orderDto.getQuantity());
-        OrderEntity orderEntity = mapper.map(orderDto, OrderEntity.class);
-
-        orderRepository.save(orderEntity);
-
-        return mapper.map(orderEntity, OrderDto.class);
-
-    }
+    /**
+     * kafka를 활용하여 DB에 저장하므로 아래 코드는 불필요
+     */
+//    @Override
+//    public OrderDto createOrder(OrderDto orderDto) {
+//
+//        ModelMapper mapper = new ModelMapper();
+//        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+//
+//        orderDto.setOrderId(UUID.randomUUID().toString());
+//        orderDto.setTotalPrice(orderDto.getPrice() * orderDto.getQuantity());
+//        orderRepository.save(orderEntity);
+//
+//        return orderDto;
+//
+//    }
 
     @Override
     public OrderDto getOrderByOrderId(String orderId) {

--- a/order-service/src/main/java/com/example/orderservice/infra/kafka/model/dto/KafkaOrderDto.java
+++ b/order-service/src/main/java/com/example/orderservice/infra/kafka/model/dto/KafkaOrderDto.java
@@ -1,0 +1,23 @@
+package com.example.orderservice.infra.kafka.model.dto;
+
+import com.example.orderservice.infra.kafka.model.vo.PayloadVO;
+import com.example.orderservice.infra.kafka.model.vo.SchemaVO;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaOrderDto {
+
+    private SchemaVO schema;
+    private PayloadVO payload;
+
+    @Builder
+    public KafkaOrderDto(SchemaVO schema, PayloadVO payload) {
+        this.schema = schema;
+        this.payload = payload;
+    }
+
+}

--- a/order-service/src/main/java/com/example/orderservice/infra/kafka/model/vo/FieldVO.java
+++ b/order-service/src/main/java/com/example/orderservice/infra/kafka/model/vo/FieldVO.java
@@ -1,0 +1,24 @@
+package com.example.orderservice.infra.kafka.model.vo;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FieldVO {
+
+    private String type;
+    private boolean optional;
+    private String field;
+
+    @Builder
+    public FieldVO(String type, boolean optional, String field) {
+        this.type = type;
+        this.optional = optional;
+        this.field = field;
+    }
+
+}
+

--- a/order-service/src/main/java/com/example/orderservice/infra/kafka/model/vo/PayloadVO.java
+++ b/order-service/src/main/java/com/example/orderservice/infra/kafka/model/vo/PayloadVO.java
@@ -1,0 +1,29 @@
+package com.example.orderservice.infra.kafka.model.vo;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PayloadVO {
+
+    private String order_id;
+    private String user_id;
+    private String product_id;
+    private int quantity;
+    private int price;
+    private int total_price;
+
+    @Builder
+    public PayloadVO(String orderId, String userId, String productId, int quantity, int price, int totalPrice) {
+        this.order_id = orderId;
+        this.user_id = userId;
+        this.product_id = productId;
+        this.quantity = quantity;
+        this.price = price;
+        this.total_price = totalPrice;
+    }
+
+}

--- a/order-service/src/main/java/com/example/orderservice/infra/kafka/model/vo/SchemaVO.java
+++ b/order-service/src/main/java/com/example/orderservice/infra/kafka/model/vo/SchemaVO.java
@@ -1,0 +1,26 @@
+package com.example.orderservice.infra.kafka.model.vo;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SchemaVO {
+
+    private String type;
+    private List<FieldVO> fields;
+    private boolean optional;
+    private String name;
+
+    @Builder
+    public SchemaVO(String type, List<FieldVO> fields, boolean optional, String name) {
+        this.type = type;
+        this.fields = fields;
+        this.optional = optional;
+        this.name = name;
+    }
+
+}

--- a/order-service/src/main/java/com/example/orderservice/infra/kafka/producer/KafkaProducer.java
+++ b/order-service/src/main/java/com/example/orderservice/infra/kafka/producer/KafkaProducer.java
@@ -1,4 +1,4 @@
-package com.example.orderservice.infra.kafka;
+package com.example.orderservice.infra.kafka.producer;
 
 import com.example.orderservice.domain.model.dto.OrderDto;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/order-service/src/main/java/com/example/orderservice/infra/kafka/producer/OrderProducer.java
+++ b/order-service/src/main/java/com/example/orderservice/infra/kafka/producer/OrderProducer.java
@@ -1,0 +1,73 @@
+package com.example.orderservice.infra.kafka.producer;
+
+import com.example.orderservice.infra.kafka.model.vo.FieldVO;
+import com.example.orderservice.infra.kafka.model.dto.KafkaOrderDto;
+import com.example.orderservice.domain.model.dto.OrderDto;
+import com.example.orderservice.infra.kafka.model.vo.PayloadVO;
+import com.example.orderservice.infra.kafka.model.vo.SchemaVO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OrderProducer {
+
+    public static final List<FieldVO> FIELDS = List.of(
+            FieldVO.builder().type("string").optional(true).field("order_id").build(),
+            FieldVO.builder().type("string").optional(true).field("user_id").build(),
+            FieldVO.builder().type("string").optional(true).field("product_id").build(),
+            FieldVO.builder().type("int32").optional(true).field("quantity").build(),
+            FieldVO.builder().type("int32").optional(true).field("price").build(),
+            FieldVO.builder().type("int32").optional(true).field("total_price").build()
+    );
+
+    public static final SchemaVO SCHEMA = SchemaVO.builder()
+            .type("struct")
+            .fields(FIELDS)
+            .optional(false)
+            .name("orders")
+            .build();
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public OrderDto sendCreateOrderMessage(String topic, OrderDto orderDto) {
+
+        PayloadVO payloadVO = PayloadVO.builder()
+                .orderId(orderDto.getOrderId())
+                .userId(orderDto.getUserId())
+                .productId(orderDto.getProductId())
+                .quantity(orderDto.getQuantity())
+                .price(orderDto.getPrice())
+                .totalPrice(orderDto.getTotalPrice())
+                .build();
+
+        KafkaOrderDto kafkaOrderDto = KafkaOrderDto.builder()
+                .schema(SCHEMA)
+                .payload(payloadVO)
+                .build();
+
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonString = "";
+
+        /* 전송할 Entity에 대한 Dto를 JSON 형태로 직렬화 */
+        try {
+            jsonString = mapper.writeValueAsString(kafkaOrderDto);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        /* 명시한 topic으로 전달 */
+        kafkaTemplate.send(topic, jsonString);
+        log.info("Kafka Producer sent data from order Microservice: {}", kafkaOrderDto);
+
+        return orderDto;
+
+    }
+
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -13,8 +13,10 @@ spring:
       path: /h2-console
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/ecommerce
+    username: root
+    password: test1234
 
   jpa:
     hibernate:

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
 eureka:
   instance:


### PR DESCRIPTION
## ✏️  What I learned today?
- KafkaOrderProducer
  - Maria DB로 교체
    - H2를 사용하여 기존에 각 마이크로서비스마다 보유하고 있던 DB를 Maria DB로 사용하여 하나의 저장소를 사용
  - 기존 : 주문 생성 요청이 들어오면 기존엔 JPA를 활용하여 Order 객체에 대한 데이터를 저장
    - 변경 : 들어온 주문에 대한 값들을 Kafka Producer를 통해 토픽에 전달하고, 토픽에 전달된 값들을 Consumer에서 받아 DB에 데이터를 삽입
      - 이때, 데이터 값을 전달하기 위해 필요한 값들에 대한 VO 객체(Schema[객체에 대한 정보], Payload[삽입할 데이터])를 생성하여 할당  